### PR TITLE
Prevent `unpack` from copying byte-arrays

### DIFF
--- a/src/msgpack/core.clj
+++ b/src/msgpack/core.clj
@@ -305,11 +305,17 @@
             (= byte 0xdf)
             (unpack-map (read-uint32 data-input) data-input)))
 
+(defn- to-byte-array
+  [bytes]
+  (if (instance? (Class/forName "[B") bytes)
+    bytes
+    (byte-array bytes)))
+
 (defn unpack
   "Unpack bytes as MessagePack object."
   [bytes]
   (-> bytes
-      byte-array
+      to-byte-array
       ByteArrayInputStream.
       DataInputStream.
       unpack-stream))


### PR DESCRIPTION
byte-array calls clojure.lang.Numbers's byte_array which creates a new
byte array and copies the object into it, regardless of the input type.
This commit changes `unpack` to only call byte-array if the input is
not already a byte-array.

To demonstrate:
```
(let [obj {"a" (byte-array (repeat 1000000 0))}
      _ (println "pack:")
      ba (time (pack obj))]
  (println "unpack:")
  (time (unpack ba)))
```

Small tests locally show ~0.5ms to pack and ~8ms to unpack before the change.
And ~0.5ms to pack and ~0.5ms to unpack after.