### PR TITLE
bump clojure dep to 1.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,7 @@
   :url "https://github.com/edma2/clojure-msgpack"
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/test.check "0.7.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]]
   :global-vars {*warn-on-reflection* true}
   :scm {:name "git"
         :url "https://github.com/edma2/clojure-msgpack"}
@@ -13,4 +12,6 @@
    {:jvm-opts
     ["-Dfile.encoding=ISO-8859-1"]}
    :eastwood {:plugins [[jonase/eastwood "0.2.3"]]
-              :eastwood {:config-files ["eastwood.clj"]}}})
+              :dependencies [[org.clojure/test.check "0.7.0"]]
+              :eastwood {:config-files ["eastwood.clj"]}}
+   :test {:dependencies [[org.clojure/test.check "0.7.0"]]}})


### PR DESCRIPTION
See issue #21.
Also declares a separate `:test` profile for testing.