### PR TITLE
Performance improvements on vector/map parsing

### DIFF
--- a/src/msgpack/core.clj
+++ b/src/msgpack/core.clj
@@ -281,7 +281,7 @@
          v (transient [])]
     (if (< i n)
       (recur
-        (inc i)
+        (unchecked-inc i)
         (conj! v (unpack-stream data-input opts)))
       (persistent! v))))
 
@@ -290,7 +290,7 @@
          m (transient {})]
     (if (< i n)
       (recur
-        (inc i)
+        (unchecked-inc i)
         (assoc! m
           (unpack-stream data-input opts)
           (unpack-stream data-input opts)))

--- a/src/msgpack/core.clj
+++ b/src/msgpack/core.clj
@@ -277,10 +277,24 @@
    (->Ext (.readByte data-input) (read-bytes n data-input))))
 
 (defn- unpack-n [n ^DataInput data-input opts]
-  (doall (for [_ (range n)] (unpack-stream data-input opts))))
+  (loop [i 0
+         v (transient [])]
+    (if (< i n)
+      (recur
+        (inc i)
+        (conj! v (unpack-stream data-input opts)))
+      (persistent! v))))
 
 (defn- unpack-map [n ^DataInput data-input opts]
-  (apply hash-map (unpack-n (* 2 n) data-input opts)))
+  (loop [i 0
+         m (transient {})]
+    (if (< i n)
+      (recur
+        (inc i)
+        (assoc! m
+          (unpack-stream data-input opts)
+          (unpack-stream data-input opts)))
+      (persistent! m))))
 
 (defn unpack-stream
   ([^DataInput data-input] (unpack-stream data-input nil))


### PR DESCRIPTION
Hey there -- 

I'm using clojure-msgpack with parsing a lot of vectors in a performance critical path of my application. Profiling revealed that the seq overhead involved with both the `(for ...)` and the `(range ...)` sequences is significant.

This diff eliminates the unnecessary allocation by:
1/ unrolling them into explicit loops w/ transients
2/ using unchecked math to avoid boxing the counter

One change to call out: unpack-n now returns a vector instead of a sequence. Happy to wrap in a call to `sequence` if that's something you're interested in maintaining (e.g. a real sequence instead of something sequential)

Tested by invoking `lein test`